### PR TITLE
Fix distro specific variables in lighttpd.conf.j2

### DIFF
--- a/templates/etc/lighttpd/lighttpd.conf.j2
+++ b/templates/etc/lighttpd/lighttpd.conf.j2
@@ -19,8 +19,8 @@ server.bind = "{{ lighttpd_server_bind_address }}"
 server.document-root = "{{ lighttpd_debian_info.default_root }}"
 server.errorlog = "/var/log/lighttpd/error.log"
 server.groupname = "www-data"
-server.max-connections = {{ (lighttpd_redhat_info.max_fds|int / 2) | round | int }}
-server.max-fds = {{ lighttpd_redhat_info.max_fds }}
+server.max-connections = {{ (lighttpd_debian_info.max_fds|int / 2) | round | int }}
+server.max-fds = {{ lighttpd_debian_info.max_fds }}
 server.pid-file = "/var/run/lighttpd.pid"
 server.port = {{ lighttpd_server_port }}
 server.upload-dirs = ( "/var/cache/lighttpd/uploads" )
@@ -40,7 +40,7 @@ var.socket_dir = home_dir + "/sockets"
 var.state_dir = "/var/run"
 var.vhosts_dir = server_root + "/vhosts"
 index-file.names += (
-  {% for item in lighttpd_debian_info.index_filenames %}"{{ item }}"{% if not loop.last %}, {% endif %}{% endfor %}
+  {% for item in lighttpd_redhat_info.index_filenames %}"{{ item }}"{% if not loop.last %}, {% endif %}{% endfor %}
 
 )
 {% if lighttpd_server_bind_address == "0.0.0.0" %}


### PR DESCRIPTION
In the template file templates/etc/lighttpd/lighttpd.conf.j2, some
variables were misused: Debian variables were used in RedHat block, and
RedHat variables were used in Debian block.

Now this is fixed.

Fix https://github.com/mrlesmithjr/ansible-lighttpd/issues/3